### PR TITLE
Sony XPERIA Mini ST15i support

### DIFF
--- a/app/src/main/res/raw/control_files.json
+++ b/app/src/main/res/raw/control_files.json
@@ -111,5 +111,12 @@
   "chargeOn": "1",
   "chargeOff": "0",
   "experimental": true
+},{
+  "file": "/sys/class/power_supply/chargalg/disable_charging",
+  "label": "chargalg/disable_charging",
+  "details": "Sony XPERIA Mini ST15i",
+  "chargeOn": "1",
+  "chargeOff": "0",
+  "experimental": true
 }
 ]

--- a/app/src/main/res/raw/control_files.json
+++ b/app/src/main/res/raw/control_files.json
@@ -115,8 +115,8 @@
   "file": "/sys/class/power_supply/chargalg/disable_charging",
   "label": "chargalg/disable_charging",
   "details": "Sony XPERIA Mini ST15i",
-  "chargeOn": "1",
-  "chargeOff": "0",
+  "chargeOn": "0",
+  "chargeOff": "1",
   "experimental": true
 }
 ]


### PR DESCRIPTION
I think I found the right file for Sony XPERIA Mini ST15i on Android 4.0.4.
The app also seems operational on an old Android. 
Why restricting for 4.4+ ?

Here's my test:
```
shell@android:/ # ll /sys/class/power_supply/chargalg/
lrwxrwxrwx root     root              2017-10-17 17:55 device -> ../../../chargalg
--w------- root     root         4096 2017-10-17 17:58 disable_charging
--w------- root     root         4096 2017-10-17 17:55 disable_usbhost
--w------- root     root         4096 2017-10-17 17:45 enable_monitoring_ambient_temp
-r--r--r-- root     root         4096 2017-10-17 18:02 health
drwxr-xr-x root     root              2017-10-17 17:55 power
lrwxrwxrwx root     root              2017-10-17 17:55 subsystem -> ../../../../../class/power_supply
-r--r--r-- root     root         4096 2017-10-17 17:55 type
-rw-r--r-- root     root         4096 2017-10-17 17:55 uevent
shell@android:/ # screencap -p /sdcard/1.png
shell@android:/ # echo 1 > /sys/class/power_supply/chargalg/disable_charging
shell@android:/ # screencap -p /sdcard/2.png
shell@android:/ # echo 0 > /sys/class/power_supply/chargalg/disable_charging
shell@android:/ # screencap -p /sdcard/3.png
```
1.png:
![1](https://user-images.githubusercontent.com/7802808/31672812-2fea5f6a-b366-11e7-9c6e-8e92e85c2fc4.png)

2.png:
![2](https://user-images.githubusercontent.com/7802808/31672813-3012916a-b366-11e7-92df-4b2988c7a92f.png)

3.png
![3](https://user-images.githubusercontent.com/7802808/31672814-30399a3a-b366-11e7-95d1-45b61a356c0a.png)
