### PR TITLE
Hold battery level

### DIFF
--- a/app/src/main/java/com/slash/batterychargelimit/Constants.kt
+++ b/app/src/main/java/com/slash/batterychargelimit/Constants.kt
@@ -24,6 +24,7 @@ object Constants {
     const val NOTIFICATION_LIVE = "notificationLive"
     const val AUTO_RESET_STATS = "auto_reset_stats"
     const val NOTIFICATION_SOUND = "notificationSound"
+    const val CHARGE_BELOW_LOWER_LIMIT_ONLY = "chargeBelowLowerLimitOnly"
 
     // ms after reaching limit, where the "unplug" event is recognized as power cut instead of action unplugging
     const val POWER_CHANGE_TOLERANCE_MS: Long = 3000

--- a/app/src/main/java/com/slash/batterychargelimit/activities/MainActivity.kt
+++ b/app/src/main/java/com/slash/batterychargelimit/activities/MainActivity.kt
@@ -25,6 +25,7 @@ import com.slash.batterychargelimit.Constants.ENABLE
 import com.slash.batterychargelimit.Constants.LIMIT
 import com.slash.batterychargelimit.Constants.MIN
 import com.slash.batterychargelimit.Constants.AUTO_RESET_STATS
+import com.slash.batterychargelimit.Constants.CHARGE_BELOW_LOWER_LIMIT_ONLY
 import com.slash.batterychargelimit.Constants.NOTIFICATION_SOUND
 import com.slash.batterychargelimit.fragments.AboutFragment
 
@@ -130,9 +131,11 @@ class MainActivity : AppCompatActivity() {
         val resetBatteryStats_Button = findViewById(R.id.reset_battery_stats) as Button
         val autoResetSwitch = findViewById(R.id.auto_stats_reset) as Switch
         val notificationSound = findViewById(R.id.notification_sound) as Switch
+        var chargeBelowLowerLimitOnly = findViewById(R.id.charge_below_lower_limit) as Switch
 
         autoResetSwitch.isChecked = settings.getBoolean(AUTO_RESET_STATS, false)
         notificationSound.isChecked = settings.getBoolean(NOTIFICATION_SOUND, false)
+        chargeBelowLowerLimitOnly.isChecked = settings.getBoolean(CHARGE_BELOW_LOWER_LIMIT_ONLY, false)
         maxPicker.minValue = 40
         maxPicker.maxValue = 99
         minPicker.minValue = 0
@@ -155,6 +158,9 @@ class MainActivity : AppCompatActivity() {
             settings.edit().putBoolean(AUTO_RESET_STATS, isChecked).apply() }
         notificationSound.setOnCheckedChangeListener { _, isChecked ->
             settings.edit().putBoolean(NOTIFICATION_SOUND, isChecked).apply() }
+        chargeBelowLowerLimitOnly.setOnCheckedChangeListener { _, isChecked ->
+            settings.edit().putBoolean(CHARGE_BELOW_LOWER_LIMIT_ONLY, isChecked).apply() }
+
 
         val statusCTRLData = findViewById(R.id.status_ctrl_data) as TextView
         statusCTRLData.text = SharedMethods.getCtrlFileData(this) + ", " +

--- a/app/src/main/java/com/slash/batterychargelimit/receivers/BatteryReceiver.kt
+++ b/app/src/main/java/com/slash/batterychargelimit/receivers/BatteryReceiver.kt
@@ -54,6 +54,9 @@ class BatteryReceiver(private val service: ForegroundService) : BroadcastReceive
                 NOTIFICATION_SOUND -> {
                     this.useNotificationSound = settings.getBoolean(NOTIFICATION_SOUND, false)
                 }
+                CHARGE_BELOW_LOWER_LIMIT_ONLY -> {
+                    this.reset(settings)
+                }
             }
         }
         prefs = PreferenceManager.getDefaultSharedPreferences(service.baseContext)

--- a/app/src/main/java/com/slash/batterychargelimit/receivers/BatteryReceiver.kt
+++ b/app/src/main/java/com/slash/batterychargelimit/receivers/BatteryReceiver.kt
@@ -5,6 +5,7 @@ import android.os.BatteryManager
 import android.os.Handler
 import android.preference.PreferenceManager
 import android.util.Log
+import com.slash.batterychargelimit.Constants.CHARGE_BELOW_LOWER_LIMIT_ONLY
 import com.slash.batterychargelimit.Constants.CHARGING_CHANGE_TOLERANCE_MS
 import com.slash.batterychargelimit.Constants.LIMIT
 import com.slash.batterychargelimit.Constants.MAX_BACK_OFF_TIME
@@ -63,7 +64,7 @@ class BatteryReceiver(private val service: ForegroundService) : BroadcastReceive
     }
 
     private fun reset(settings: SharedPreferences) {
-        chargedToLimit = false
+        chargedToLimit = settings.getBoolean(CHARGE_BELOW_LOWER_LIMIT_ONLY, false)
         lastState = -1
         backOffTime = CHARGING_CHANGE_TOLERANCE_MS
         limitPercentage = settings.getInt(LIMIT, 80)
@@ -121,7 +122,7 @@ class BatteryReceiver(private val service: ForegroundService) : BroadcastReceive
                 service.setNotificationIcon(NOTIF_CHARGE)
                 stopIfUnplugged()
             }
-        } else if (batteryLevel >= limitPercentage) {
+        } else if (batteryLevel >= limitPercentage || (chargedToLimit && batteryLevel >= rechargePercentage)) {
             if (switchState(CHARGE_STOP)) {
                 Log.d("Charging State", "CHARGE_STOP " + this.hashCode())
                 // play sound only the first time when the limit was reached

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -128,6 +128,18 @@
                         android:layout_marginTop="12dp"
                         />
 
+                    <Switch
+                        android:id="@+id/charge_below_lower_limit"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentBottom="false"
+                        android:layout_alignParentLeft="false"
+                        android:layout_alignParentStart="false"
+                        android:layout_below="@+id/notification_sound"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/charge_below_lower_limit"
+                        android:textSize="16sp" />
+
                 </RelativeLayout>
             </android.support.v7.widget.CardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,5 @@
     <string name="custom_ctrl_file_updated_info">Updated data will appear here once you update the information</string>
     <string name="custom_ctrl_file_heads_up">If you experience issues with app crashes or the service not working properly, try enabling Always Write CTRL File in settings. There is NO guarantee that this configurable control file function will support all devices and files/values. Try adjusting the settings if issues occur or ensure the data is correct.</string>
     <string name="custom_ctrl_file_update_data">UPDATE CTRL FILE DATA</string>
+    <string name="charge_below_lower_limit">Don\'t charge if above lower limit</string>
 </resources>


### PR DESCRIPTION
**What does this do**
Add option to hold the current battery level when the device gets plugged in and battery level is above the lower limit and below the upper limit.

**Why could this be useful**
This might be useful when the device gets plugged in and out multiple times a day, for example when the device is used with external display and input devices. Prevents the battery from being charged over and over again.

**Further suggestions are very welcome**