### PR TITLE
Allow parameter `intent` in ForegroundService#onStartCommand to be null

### DIFF
--- a/app/src/main/java/com/slash/batterychargelimit/ForegroundService.kt
+++ b/app/src/main/java/com/slash/batterychargelimit/ForegroundService.kt
@@ -66,7 +66,7 @@ class ForegroundService : Service() {
         registerReceiver(batteryReceiver, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
     }
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         ignoreAutoReset = false
         return super.onStartCommand(intent, flags, startId)
     }


### PR DESCRIPTION
[Parameter `intent` of `Service#onStartCommand` can be null.](https://developer.android.com/reference/android/app/Service.html#onStartCommand\(android.content.Intent,%20int,%20int\))

Fixes the following crash:

```
04-23 19:37:04.184 11214 11214 E AndroidRuntime: FATAL EXCEPTION: main
04-23 19:37:04.184 11214 11214 E AndroidRuntime: Process: com.slash.batterychargelimit, PID: 11214
04-23 19:37:04.184 11214 11214 E AndroidRuntime: java.lang.RuntimeException: Unable to start service com.slash.batterychargelimit.ForegroundService@a8c85ec with null: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.slash.batterychargelimit.ForegroundService.onStartCommand, parameter intent
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:3635)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.app.ActivityThread.-wrap20(Unknown Source:0)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1791)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:164)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:6753)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:482)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
04-23 19:37:04.184 11214 11214 E AndroidRuntime: Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.slash.batterychargelimit.ForegroundService.onStartCommand, parameter intent
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at com.slash.batterychargelimit.ForegroundService.onStartCommand(Unknown Source:2)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:3618)
04-23 19:37:04.184 11214 11214 E AndroidRuntime:        ... 8 more
```