### PR TITLE
Mediatek charge control file description

### DIFF
--- a/app/src/main/res/raw/control_files.json
+++ b/app/src/main/res/raw/control_files.json
@@ -195,5 +195,12 @@
     "chargeOn": "0",
     "chargeOff": "1",
     "experimental": true
+  },
+  {
+    "file": "/proc/mtk_battery_cmd/current_cmd",
+    "label": "MtkBattery",
+    "details": "Alcatel 5059D, other MediaTek devices",
+    "chargeOn": "0 0",
+    "chargeOff": "0 1"
   }
 ]


### PR DESCRIPTION
Added a charge control file for some Mediatek devices. Tested on Alcatel 5059D.