### PR TITLE
control file for OnePlus Nord 2T 5G

### DIFF
--- a/app/src/main/res/raw/control_files.json
+++ b/app/src/main/res/raw/control_files.json
@@ -195,5 +195,13 @@
     "chargeOn": "0",
     "chargeOff": "1",
     "experimental": true
+  },
+  {
+    "file": "/sys/devices/virtual/oplus_chg/battery/mmi_charging_enable",
+    "label": "OnePlus",
+    "details": "OnePlus Nord 2T 5G",
+    "chargeOn": "1",
+    "chargeOff": "0",
+    "experimental": true
   }
 ]


### PR DESCRIPTION
Added control file for OnePlus Nord 2T 5G. The app works with both "normal" and fast (VOOC) charge.